### PR TITLE
Introduce ci to run shellcheck

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,4 +9,6 @@ trigger:
 
 steps:
 - script: |
-    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck */entrypoint.sh
+    for SCRIPT in $(find . -type f -name \*\.sh | xargs); do
+      docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck $SCRIPT
+    done

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,22 @@
+resources:
+- repo: self
+
+pool:
+  vmimage: 'ubuntu-16.04'
+
+trigger:
+- master
+
+steps:
+- script: |
+    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck aks/entrypoint.sh
+    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck arm/entrypoint.sh
+    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck cli/entrypoint.sh
+    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck containerwebapp/entrypoint.sh
+    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck dotnetcore-cli/entrypoint.sh
+    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck functions/entrypoint.sh
+    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck functionscontainer/entrypoint.sh
+    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck login/entrypoint.sh
+    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck pipelines/entrypoint.sh
+    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck releasepipelines/entrypoint.sh
+    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck webapp/entrypoint.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,14 +9,4 @@ trigger:
 
 steps:
 - script: |
-    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck aks/entrypoint.sh
-    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck arm/entrypoint.sh
-    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck cli/entrypoint.sh
-    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck containerwebapp/entrypoint.sh
-    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck dotnetcore-cli/entrypoint.sh
-    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck functions/entrypoint.sh
-    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck functionscontainer/entrypoint.sh
-    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck login/entrypoint.sh
-    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck pipelines/entrypoint.sh
-    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck releasepipelines/entrypoint.sh
-    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck webapp/entrypoint.sh
+    docker run --rm -v '$(Build.SourcesDirectory):/mnt' -t koalaman/shellcheck */entrypoint.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ resources:
 - repo: self
 
 pool:
-  vmimage: 'ubuntu-16.04'
+  vmImage: 'ubuntu-16.04'
 
 trigger:
 - master


### PR DESCRIPTION
Introduce an `azure-pipelines.yml` that runs shellcheck against the various `entrypoint.sh` scripts.

[shellcheck](http://shellcheck.net/) is a linter for Bourne shell scripts that locates code that may be problematic under certain circumstances like accidental word splitting, globbing or exit code validation.

Although one could deduce that several of the warnings are not able to be triggered (eg, `FOO=bar; echo $FOO` obviously needs no quoting around the usage of `$FOO`), it does typically find usage of uncommon style that could be problematic, especially during a refactoring where such assumptions become violated.

Note that this does _not_ actually wire up the CI system, it only provides a definition that could be used.  I would be happy to assist with the provisioning of the CI system as well.