### PR TITLE
Azure DevOps configuration updates

### DIFF
--- a/boards/README.md
+++ b/boards/README.md
@@ -12,25 +12,25 @@ issue is closed, the corresponding work item will also be moved to the
 action "Create Azure Boards Work Item" {
   uses = "azure/github-actions/boards@master"
   env = {
-		AZURE_BOARDS_ORGANIZATION = "<Azure Boards Organization Name>"
-		AZURE_BOARDS_PROJECT = "<Azure Boards Project Name>"
+		AZURE_DEVOPS_ORGANIZATION = "<Azure DevOps Organization Name>"
+		AZURE_DEVOPS_PROJECT = "<Azure DevOps Project Name>"
 		AZURE_BOARDS_TYPE= "<Azure Boards Work Item Type>"
 		AZURE_BOARDS_CLOSED_STATE= "<Azure Boards Work Item State>"
 		AZURE_BOARDS_REOPENED_STATE= "<Azure Boards Work Item State>"
 	}
-  secrets = ["AZURE_BOARDS_TOKEN"]
+  secrets = ["AZURE_DEVOPS_TOKEN"]
 }
 ```
 
 ### Secrets
 
-- `AZURE_BOARDS_TOKEN` – **Mandatory**; an access token to be used when creating/updating work items.  See [Authenticate access with personal access tokens](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops) for details. 
+- `AZURE_DEVOPS_TOKEN` – **Mandatory**; an access token to be used when creating/updating work items.  See [Authenticate access with personal access tokens](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops) for details. 
 
 
 ### Environment variables
 
-- `AZURE_BOARDS_ORGANIZATION` – **Mandatory**
-- `AZURE_BOARDS_PROJECT` – **Mandatory** 
+- `AZURE_DEVOPS_ORGANIZATION` – **Mandatory**
+- `AZURE_DEVOPS_PROJECT` – **Mandatory** 
 - `AZURE_BOARDS_TYPE` – **Optional**; the type of work item to create.  Defaults to "Feature" if unset.  See [process doeumentation](https://docs.microsoft.com/en-us/azure/devops/boards/work-items/guidance/choose-process?view=azure-devops) for more details on work item types.
 - `AZURE_BOARDS_CLOSED_STATE` - **Optional**; the state to move the work item to when the GitHub issue is closed.  Defaults to "Closed" if unset.
 - `AZURE_BOARDS_REOPENED_STATE` - **Optional**; the state to move the work item to when the GitHub issue is reopened.  Defaults to "New" if unset.

--- a/boards/README.md
+++ b/boards/README.md
@@ -12,6 +12,7 @@ issue is closed, the corresponding work item will also be moved to the
 action "Create Azure Boards Work Item" {
   uses = "azure/github-actions/boards@master"
   env = {
+		AZURE_DEVOPS_URL = "<Azure DevOps URL>"
 		AZURE_DEVOPS_ORGANIZATION = "<Azure DevOps Organization Name>"
 		AZURE_DEVOPS_PROJECT = "<Azure DevOps Project Name>"
 		AZURE_BOARDS_TYPE= "<Azure Boards Work Item Type>"
@@ -29,8 +30,15 @@ action "Create Azure Boards Work Item" {
 
 ### Environment variables
 
-- `AZURE_DEVOPS_ORGANIZATION` – **Mandatory**
-- `AZURE_DEVOPS_PROJECT` – **Mandatory** 
+One of `AZURE_DEVOPS_URL` or `AZURE_DEVOPS_ORGANIZATION` is mandatory.
+In case both are defined, `AZURE_DEVOPS_URL` gets preference.
+
+- `AZURE_DEVOPS_URL` – **Optional**; the fully-qualified URL to the Azure DevOps organization (eg, `https://dev.azure.com/organization` or `https://server.example.com:8080/tfs/DefaultCollection`)
+- `AZURE_DEVOPS_ORGANIZATION` – **Optional**; the Azure DevOps organization name.  The URL to Azure DevOps will be derived from this.
+
+Additional configuration:
+
+- `AZURE_DEVOPS_PROJECT` – **Mandatory**; the name of the Azure DevOps project that contains the boards
 - `AZURE_BOARDS_TYPE` – **Optional**; the type of work item to create.  Defaults to "Feature" if unset.  See [process doeumentation](https://docs.microsoft.com/en-us/azure/devops/boards/work-items/guidance/choose-process?view=azure-devops) for more details on work item types.
 - `AZURE_BOARDS_CLOSED_STATE` - **Optional**; the state to move the work item to when the GitHub issue is closed.  Defaults to "Closed" if unset.
 - `AZURE_BOARDS_REOPENED_STATE` - **Optional**; the state to move the work item to when the GitHub issue is reopened.  Defaults to "New" if unset.

--- a/boards/README.md
+++ b/boards/README.md
@@ -13,7 +13,6 @@ action "Create Azure Boards Work Item" {
   uses = "azure/github-actions/boards@master"
   env = {
 		AZURE_DEVOPS_URL = "<Azure DevOps URL>"
-		AZURE_DEVOPS_ORGANIZATION = "<Azure DevOps Organization Name>"
 		AZURE_DEVOPS_PROJECT = "<Azure DevOps Project Name>"
 		AZURE_BOARDS_TYPE= "<Azure Boards Work Item Type>"
 		AZURE_BOARDS_CLOSED_STATE= "<Azure Boards Work Item State>"
@@ -30,14 +29,7 @@ action "Create Azure Boards Work Item" {
 
 ### Environment variables
 
-One of `AZURE_DEVOPS_URL` or `AZURE_DEVOPS_ORGANIZATION` is mandatory.
-In case both are defined, `AZURE_DEVOPS_URL` gets preference.
-
-- `AZURE_DEVOPS_URL` – **Optional**; the fully-qualified URL to the Azure DevOps organization (eg, `https://dev.azure.com/organization` or `https://server.example.com:8080/tfs/DefaultCollection`)
-- `AZURE_DEVOPS_ORGANIZATION` – **Optional**; the Azure DevOps organization name.  The URL to Azure DevOps will be derived from this.
-
-Additional configuration:
-
+- `AZURE_DEVOPS_URL` – **Mandatory**; the fully-qualified URL to the Azure DevOps organization (eg, `https://dev.azure.com/organization` or `https://server.example.com:8080/tfs/DefaultCollection`)
 - `AZURE_DEVOPS_PROJECT` – **Mandatory**; the name of the Azure DevOps project that contains the boards
 - `AZURE_BOARDS_TYPE` – **Optional**; the type of work item to create.  Defaults to "Feature" if unset.  See [process doeumentation](https://docs.microsoft.com/en-us/azure/devops/boards/work-items/guidance/choose-process?view=azure-devops) for more details on work item types.
 - `AZURE_BOARDS_CLOSED_STATE` - **Optional**; the state to move the work item to when the GitHub issue is closed.  Defaults to "Closed" if unset.

--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -2,18 +2,18 @@
 
 set -e 
 
-if [ -z "$AZURE_BOARDS_ORGANIZATION" ]; then
-    echo "AZURE_BOARDS_ORGANIZATION is not set." >&2
+if [ -z "$AZURE_DEVOPS_ORGANIZATION" ]; then
+    echo "AZURE_DEVOPS_ORGANIZATION is not set." >&2
     exit 1
 fi
 
-if [ -z "$AZURE_BOARDS_PROJECT" ]; then
-    echo "AZURE_BOARDS_PROJECT is not set." >&2
+if [ -z "$AZURE_DEVOPS_PROJECT" ]; then
+    echo "AZURE_DEVOPS_PROJECT is not set." >&2
     exit 1
 fi
 
-if [ -z "$AZURE_BOARDS_TOKEN" ]; then
-    echo "AZURE_BOARDS_TOKEN is not set." >&2
+if [ -z "$AZURE_DEVOPS_TOKEN" ]; then
+    echo "AZURE_DEVOPS_TOKEN is not set." >&2
     exit 1
 fi
 
@@ -47,11 +47,11 @@ function work_items_for_issue {
 AZURE_BOARDS_TYPE="${AZURE_BOARDS_TYPE:-Feature}"
 AZURE_BOARDS_CLOSED_STATE="${AZURE_BOARDS_CLOSED_STATE:-Closed}"
 AZURE_BOARDS_REOPENED_STATE="${AZURE_BOARDS_REOPENED_STATE:-Active}"
-AZURE_DEVOPS_URL="https://dev.azure.com/${AZURE_BOARDS_ORGANIZATION}/"
+AZURE_DEVOPS_URL="https://dev.azure.com/${AZURE_DEVOPS_ORGANIZATION}/"
 
-vsts configure --defaults instance="${AZURE_DEVOPS_URL}" project="${AZURE_BOARDS_PROJECT}"
+vsts configure --defaults instance="${AZURE_DEVOPS_URL}" project="${AZURE_DEVOPS_PROJECT}"
 
-vsts login --token "${AZURE_BOARDS_TOKEN}"
+vsts login --token "${AZURE_DEVOPS_TOKEN}"
 
 GITHUB_EVENT=$(jq --raw-output 'if .comment != null then "comment" else empty end' "$GITHUB_EVENT_PATH")
 GITHUB_EVENT=${GITHUB_EVENT:-$(jq --raw-output 'if .issue != null then "issue" else empty end' "$GITHUB_EVENT_PATH")}

--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -2,8 +2,8 @@
 
 set -e 
 
-if [ -z "$AZURE_DEVOPS_URL" -a -z "$AZURE_DEVOPS_ORGANIZATION" ]; then
-    echo "AZURE_DEVOPS_URL and AZURE_DEVOPS_ORGANIZATION are not set." >&2
+if [ -z "$AZURE_DEVOPS_URL" ]; then
+    echo "AZURE_DEVOPS_URL is not set." >&2
     exit 1
 fi
 
@@ -43,10 +43,6 @@ function create_work_item {
 function work_items_for_issue {
     vsts work item query --wiql "SELECT ID FROM workitems WHERE [System.Tags] CONTAINS 'GitHub' AND [System.Tags] CONTAINS 'Issue ${GITHUB_ISSUE_NUMBER}' AND [System.Tags] CONTAINS '${GITHUB_REPO_FULL_NAME}'" | jq '.[].id' | xargs
 }
-
-if [ -z "$AZURE_DEVOPS_URL" ]; then
-    AZURE_DEVOPS_URL="https://dev.azure.com/${AZURE_DEVOPS_ORGANIZATION}/"
-fi
 
 AZURE_BOARDS_TYPE="${AZURE_BOARDS_TYPE:-Feature}"
 AZURE_BOARDS_CLOSED_STATE="${AZURE_BOARDS_CLOSED_STATE:-Closed}"

--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -2,8 +2,8 @@
 
 set -e 
 
-if [ -z "$AZURE_DEVOPS_ORGANIZATION" ]; then
-    echo "AZURE_DEVOPS_ORGANIZATION is not set." >&2
+if [ -z "$AZURE_DEVOPS_URL" -a -z "$AZURE_DEVOPS_ORGANIZATION" ]; then
+    echo "AZURE_DEVOPS_URL and AZURE_DEVOPS_ORGANIZATION are not set." >&2
     exit 1
 fi
 
@@ -44,10 +44,13 @@ function work_items_for_issue {
     vsts work item query --wiql "SELECT ID FROM workitems WHERE [System.Tags] CONTAINS 'GitHub' AND [System.Tags] CONTAINS 'Issue ${GITHUB_ISSUE_NUMBER}' AND [System.Tags] CONTAINS '${GITHUB_REPO_FULL_NAME}'" | jq '.[].id' | xargs
 }
 
+if [ -z "$AZURE_DEVOPS_URL" ]; then
+    AZURE_DEVOPS_URL="https://dev.azure.com/${AZURE_DEVOPS_ORGANIZATION}/"
+fi
+
 AZURE_BOARDS_TYPE="${AZURE_BOARDS_TYPE:-Feature}"
 AZURE_BOARDS_CLOSED_STATE="${AZURE_BOARDS_CLOSED_STATE:-Closed}"
 AZURE_BOARDS_REOPENED_STATE="${AZURE_BOARDS_REOPENED_STATE:-Active}"
-AZURE_DEVOPS_URL="https://dev.azure.com/${AZURE_DEVOPS_ORGANIZATION}/"
 
 vsts configure --defaults instance="${AZURE_DEVOPS_URL}" project="${AZURE_DEVOPS_PROJECT}"
 

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -10,7 +10,6 @@ action "Trigger Azure Pipelines" {
   uses = "Azure/github-actions/pipelines@master"
   env = {
 		AZURE_DEVOPS_URL = "<Azure DevOps URL>"
-		AZURE_DEVOPS_ORGANIZATION = "<Azure DevOps Organization Name>"
 		AZURE_DEVOPS_PROJECT = "<Azure DevOps Project Name>"
 		AZURE_PIPELINE_NAME= "<Azure Pipeline Name>"
 	}
@@ -27,14 +26,7 @@ action "Trigger Azure Pipelines" {
 
 ### Environment variables
 
-One of `AZURE_DEVOPS_URL` or `AZURE_DEVOPS_ORGANIZATION` is mandatory.
-In case both are defined, `AZURE_DEVOPS_URL` gets preference.
-
-- `AZURE_DEVOPS_URL` – **Optional**; the fully-qualified URL to the Azure DevOps organization (eg, `https://dev.azure.com/organization` or `https://server.example.com:8080/tfs/DefaultCollection`)
-- `AZURE_DEVOPS_ORGANIZATION` – **Optional**; the Azure DevOps organization name.  The URL to Azure DevOps will be derived from this.
-
-Additional configuration:
-
+- `AZURE_DEVOPS_URL` – **Mandatory**; the fully-qualified URL to the Azure DevOps organization (eg, `https://dev.azure.com/organization` or `https://server.example.com:8080/tfs/DefaultCollection`)
 - `AZURE_DEVOPS_PROJECT` – **Mandatory** 
 - `AZURE_PIPELINE_NAME` – **Mandatory** 
 

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -9,6 +9,7 @@
 action "Trigger Azure Pipelines" {
   uses = "Azure/github-actions/pipelines@master"
   env = {
+		AZURE_DEVOPS_URL = "<Azure DevOps URL>"
 		AZURE_DEVOPS_ORGANIZATION = "<Azure DevOps Organization Name>"
 		AZURE_DEVOPS_PROJECT = "<Azure DevOps Project Name>"
 		AZURE_PIPELINE_NAME= "<Azure Pipeline Name>"
@@ -26,7 +27,14 @@ action "Trigger Azure Pipelines" {
 
 ### Environment variables
 
-- `AZURE_DEVOPS_ORGANIZATION` – **Mandatory** 
+One of `AZURE_DEVOPS_URL` or `AZURE_DEVOPS_ORGANIZATION` is mandatory.
+In case both are defined, `AZURE_DEVOPS_URL` gets preference.
+
+- `AZURE_DEVOPS_URL` – **Optional**; the fully-qualified URL to the Azure DevOps organization (eg, `https://dev.azure.com/organization` or `https://server.example.com:8080/tfs/DefaultCollection`)
+- `AZURE_DEVOPS_ORGANIZATION` – **Optional**; the Azure DevOps organization name.  The URL to Azure DevOps will be derived from this.
+
+Additional configuration:
+
 - `AZURE_DEVOPS_PROJECT` – **Mandatory** 
 - `AZURE_PIPELINE_NAME` – **Mandatory** 
 

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -9,11 +9,11 @@
 action "Trigger Azure Pipelines" {
   uses = "Azure/github-actions/pipelines@master"
   env = {
-		AZURE_PIPELINE_ORGANIZATION = "<Azure Organization Name>"
-		AZURE_PIPELINE_PROJECT = "<Azure Project Name>"
+		AZURE_DEVOPS_ORGANIZATION = "<Azure DevOps Organization Name>"
+		AZURE_DEVOPS_PROJECT = "<Azure DevOps Project Name>"
 		AZURE_PIPELINE_NAME= "<Azure Pipeline Name>"
 	}
-  secrets = ["AZURE_PIPELINE_TOKEN"]
+  secrets = ["AZURE_DEVOPS_TOKEN"]
 }
 
 ```
@@ -21,13 +21,13 @@ action "Trigger Azure Pipelines" {
 
 ### Secrets
 
-- `AZURE_PIPELINE_TOKEN` – **Mandatory** 
+- `AZURE_DEVOPS_TOKEN` – **Mandatory** 
 
 
 ### Environment variables
 
-- `AZURE_PIPELINE_ORGANIZATION` – **Mandatory** 
-- `AZURE_PIPELINE_PROJECT` – **Mandatory** 
+- `AZURE_DEVOPS_ORGANIZATION` – **Mandatory** 
+- `AZURE_DEVOPS_PROJECT` – **Mandatory** 
 - `AZURE_PIPELINE_NAME` – **Mandatory** 
 
 

--- a/pipelines/entrypoint.sh
+++ b/pipelines/entrypoint.sh
@@ -2,8 +2,8 @@
 
 set -e 
 
-if [ -z "$AZURE_DEVOPS_ORGANIZATION" ]; then
-    echo "AZURE_DEVOPS_ORGANIZATION is not set." >&2
+if [ -z "$AZURE_DEVOPS_URL" -a -z "$AZURE_DEVOPS_ORGANIZATION" ]; then
+    echo "AZURE_DEVOPS_URL and AZURE_DEVOPS_ORGANIZATION are not set." >&2
     exit 1
 fi
 
@@ -22,9 +22,11 @@ if [ -z "$AZURE_PIPELINE_NAME" ]; then
     exit 1
 fi
 
+if [ -z "$AZURE_DEVOPS_URL" ]; then
+    AZURE_DEVOPS_URL="https://dev.azure.com/${AZURE_DEVOPS_ORGANIZATION}/"
+fi
     
-AZDEVOPS_URL="https://dev.azure.com/${AZURE_DEVOPS_ORGANIZATION}/"
-vsts configure --defaults instance="${AZDEVOPS_URL}" project="${AZURE_DEVOPS_PROJECT}"
+vsts configure --defaults instance="${AZURE_DEVOPS_URL}" project="${AZURE_DEVOPS_PROJECT}"
     
 vsts login --token "${AZURE_DEVOPS_TOKEN}"
     

--- a/pipelines/entrypoint.sh
+++ b/pipelines/entrypoint.sh
@@ -2,27 +2,23 @@
 
 set -e 
 
-if [ -z "$AZURE_PIPELINE_ORGANIZATION" ]; 
-then
-    echo "\$AZURE_PIPELINE_ORGANIZATION is not set." >&2
+if [ -z "$AZURE_PIPELINE_ORGANIZATION" ]; then
+    echo "AZURE_PIPELINE_ORGANIZATION is not set." >&2
     exit 1
 fi
 
-if [ -z "$AZURE_PIPELINE_PROJECT" ]; 
-then
-    echo "\$AZURE_PIPELINE_PROJECT is not set." >&2
+if [ -z "$AZURE_PIPELINE_PROJECT" ]; then
+    echo "AZURE_PIPELINE_PROJECT is not set." >&2
     exit 1
 fi
 
-if [ -z "$AZURE_PIPELINE_TOKEN" ]; 
-then
-    echo "\$AZURE_PIPELINE_TOKEN is not set." >&2
+if [ -z "$AZURE_PIPELINE_TOKEN" ]; then
+    echo "AZURE_PIPELINE_TOKEN is not set." >&2
     exit 1
 fi
 
-if [ -z "$AZURE_PIPELINE_NAME" ]; 
-then
-    echo "\$AZURE_PIPELINE_NAME is not set." >&2
+if [ -z "$AZURE_PIPELINE_NAME" ]; then
+    echo "AZURE_PIPELINE_NAME is not set." >&2
     exit 1
 fi
 

--- a/pipelines/entrypoint.sh
+++ b/pipelines/entrypoint.sh
@@ -2,8 +2,8 @@
 
 set -e 
 
-if [ -z "$AZURE_DEVOPS_URL" -a -z "$AZURE_DEVOPS_ORGANIZATION" ]; then
-    echo "AZURE_DEVOPS_URL and AZURE_DEVOPS_ORGANIZATION are not set." >&2
+if [ -z "$AZURE_DEVOPS_URL" ]; then
+    echo "AZURE_DEVOPS_URL is not set." >&2
     exit 1
 fi
 
@@ -22,10 +22,6 @@ if [ -z "$AZURE_PIPELINE_NAME" ]; then
     exit 1
 fi
 
-if [ -z "$AZURE_DEVOPS_URL" ]; then
-    AZURE_DEVOPS_URL="https://dev.azure.com/${AZURE_DEVOPS_ORGANIZATION}/"
-fi
-    
 vsts configure --defaults instance="${AZURE_DEVOPS_URL}" project="${AZURE_DEVOPS_PROJECT}"
     
 vsts login --token "${AZURE_DEVOPS_TOKEN}"

--- a/pipelines/entrypoint.sh
+++ b/pipelines/entrypoint.sh
@@ -2,18 +2,18 @@
 
 set -e 
 
-if [ -z "$AZURE_PIPELINE_ORGANIZATION" ]; then
-    echo "AZURE_PIPELINE_ORGANIZATION is not set." >&2
+if [ -z "$AZURE_DEVOPS_ORGANIZATION" ]; then
+    echo "AZURE_DEVOPS_ORGANIZATION is not set." >&2
     exit 1
 fi
 
-if [ -z "$AZURE_PIPELINE_PROJECT" ]; then
-    echo "AZURE_PIPELINE_PROJECT is not set." >&2
+if [ -z "$AZURE_DEVOPS_PROJECT" ]; then
+    echo "AZURE_DEVOPS_PROJECT is not set." >&2
     exit 1
 fi
 
-if [ -z "$AZURE_PIPELINE_TOKEN" ]; then
-    echo "AZURE_PIPELINE_TOKEN is not set." >&2
+if [ -z "$AZURE_DEVOPS_TOKEN" ]; then
+    echo "AZURE_DEVOPS_TOKEN is not set." >&2
     exit 1
 fi
 
@@ -23,10 +23,10 @@ if [ -z "$AZURE_PIPELINE_NAME" ]; then
 fi
 
     
-AZDEVOPS_URL="https://dev.azure.com/${AZURE_PIPELINE_ORGANIZATION}/"
-vsts configure --defaults instance="${AZDEVOPS_URL}" project="${AZURE_PIPELINE_PROJECT}"
+AZDEVOPS_URL="https://dev.azure.com/${AZURE_DEVOPS_ORGANIZATION}/"
+vsts configure --defaults instance="${AZDEVOPS_URL}" project="${AZURE_DEVOPS_PROJECT}"
     
-vsts login --token "${AZURE_PIPELINE_TOKEN}"
+vsts login --token "${AZURE_DEVOPS_TOKEN}"
     
 PIPELINES=$(vsts build definition list --name "${AZURE_PIPELINE_NAME}" --output json)
 

--- a/releasepipelines/README.md
+++ b/releasepipelines/README.md
@@ -9,6 +9,7 @@
 action "Trigger Azure Release Pipelines" {
   uses = "Azure/github-actions/releasepipelines@master"
   env = {
+		AZURE_DEVOPS_URL = "<Azure DevOps URL>"
 		AZURE_DEVOPS_ORGANIZATION = "<Azure DevOps Organization Name>"
 		AZURE_DEVOPS_PROJECT = "<Azure DevOps Project Name>"
 		AZURE_PIPELINE_NAME= "<Azure Pipeline Name>"
@@ -26,7 +27,14 @@ action "Trigger Azure Release Pipelines" {
 
 ### Environment variables
 
-- `AZURE_DEVOPS_ORGANIZATION` – **Mandatory** 
+One of `AZURE_DEVOPS_URL` or `AZURE_DEVOPS_ORGANIZATION` is mandatory.
+In case both are defined, `AZURE_DEVOPS_URL` gets preference.
+
+- `AZURE_DEVOPS_URL` – **Optional**; the fully-qualified URL to the Azure DevOps organization (eg, `https://dev.azure.com/organization` or `https://server.example.com:8080/tfs/DefaultCollection`)
+- `AZURE_DEVOPS_ORGANIZATION` – **Optional**; the Azure DevOps organization name.  The URL to Azure DevOps will be derived from this.
+
+Additional configuration:
+
 - `AZURE_DEVOPS_PROJECT` – **Mandatory** 
 - `AZURE_PIPELINE_NAME` – **Mandatory** 
 

--- a/releasepipelines/README.md
+++ b/releasepipelines/README.md
@@ -10,7 +10,6 @@ action "Trigger Azure Release Pipelines" {
   uses = "Azure/github-actions/releasepipelines@master"
   env = {
 		AZURE_DEVOPS_URL = "<Azure DevOps URL>"
-		AZURE_DEVOPS_ORGANIZATION = "<Azure DevOps Organization Name>"
 		AZURE_DEVOPS_PROJECT = "<Azure DevOps Project Name>"
 		AZURE_PIPELINE_NAME= "<Azure Pipeline Name>"
 	}
@@ -27,14 +26,7 @@ action "Trigger Azure Release Pipelines" {
 
 ### Environment variables
 
-One of `AZURE_DEVOPS_URL` or `AZURE_DEVOPS_ORGANIZATION` is mandatory.
-In case both are defined, `AZURE_DEVOPS_URL` gets preference.
-
-- `AZURE_DEVOPS_URL` – **Optional**; the fully-qualified URL to the Azure DevOps organization (eg, `https://dev.azure.com/organization` or `https://server.example.com:8080/tfs/DefaultCollection`)
-- `AZURE_DEVOPS_ORGANIZATION` – **Optional**; the Azure DevOps organization name.  The URL to Azure DevOps will be derived from this.
-
-Additional configuration:
-
+- `AZURE_DEVOPS_URL` – **Mandatory**; the fully-qualified URL to the Azure DevOps organization (eg, `https://dev.azure.com/organization` or `https://server.example.com:8080/tfs/DefaultCollection`)
 - `AZURE_DEVOPS_PROJECT` – **Mandatory** 
 - `AZURE_PIPELINE_NAME` – **Mandatory** 
 

--- a/releasepipelines/README.md
+++ b/releasepipelines/README.md
@@ -9,11 +9,11 @@
 action "Trigger Azure Release Pipelines" {
   uses = "Azure/github-actions/releasepipelines@master"
   env = {
-		AZURE_PIPELINE_ORGANIZATION = "<Azure Organization Name>"
-		AZURE_PIPELINE_PROJECT = "<Azure Project Name>"
+		AZURE_DEVOPS_ORGANIZATION = "<Azure DevOps Organization Name>"
+		AZURE_DEVOPS_PROJECT = "<Azure DevOps Project Name>"
 		AZURE_PIPELINE_NAME= "<Azure Pipeline Name>"
 	}
-  secrets = ["AZURE_PIPELINE_TOKEN"]
+  secrets = ["AZURE_DEVOPS_TOKEN"]
 }
 
 ```
@@ -21,13 +21,13 @@ action "Trigger Azure Release Pipelines" {
 
 ### Secrets
 
-- `AZURE_PIPELINE_TOKEN` – **Mandatory** 
+- `AZURE_DEVOPS_TOKEN` – **Mandatory** 
 
 
 ### Environment variables
 
-- `AZURE_PIPELINE_ORGANIZATION` – **Mandatory** 
-- `AZURE_PIPELINE_PROJECT` – **Mandatory** 
+- `AZURE_DEVOPS_ORGANIZATION` – **Mandatory** 
+- `AZURE_DEVOPS_PROJECT` – **Mandatory** 
 - `AZURE_PIPELINE_NAME` – **Mandatory** 
 
 

--- a/releasepipelines/entrypoint.sh
+++ b/releasepipelines/entrypoint.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 set -e
 
-if [ -z "$AZURE_PIPELINE_ORGANIZATION" ]; then
-    echo "AZURE_PIPELINE_ORGANIZATION is not set."
+if [ -z "$AZURE_DEVOPS_ORGANIZATION" ]; then
+    echo "AZURE_DEVOPS_ORGANIZATION is not set."
     exit 1
 fi
 
-if [ -z "$AZURE_PIPELINE_PROJECT" ]; then
-    echo "AZURE_PIPELINE_PROJECT is not set."
+if [ -z "$AZURE_DEVOPS_PROJECT" ]; then
+    echo "AZURE_DEVOPS_PROJECT is not set."
     exit 1
 fi
 
-if [ -z "$AZURE_PIPELINE_TOKEN" ]; then
-    echo "AZURE_PIPELINE_TOKEN is not set."
+if [ -z "$AZURE_DEVOPS_TOKEN" ]; then
+    echo "AZURE_DEVOPS_TOKEN is not set."
     exit 1
 fi
 
@@ -22,10 +22,10 @@ if [ -z "$AZURE_PIPELINE_NAME" ]; then
 fi
 
     
-AZDEVOPS_URL="https://dev.azure.com/${AZURE_PIPELINE_ORGANIZATION}/"
-vsts configure --defaults instance="${AZDEVOPS_URL}" project="${AZURE_PIPELINE_PROJECT}"
+AZDEVOPS_URL="https://dev.azure.com/${AZURE_DEVOPS_ORGANIZATION}/"
+vsts configure --defaults instance="${AZDEVOPS_URL}" project="${AZURE_DEVOPS_PROJECT}"
     
-vsts login --token "${AZURE_PIPELINE_TOKEN}"
+vsts login --token "${AZURE_DEVOPS_TOKEN}"
 
 # List RDs with given pipeline name
 PIPELINES=$(vsts release definition list --name "${AZURE_PIPELINE_NAME}")

--- a/releasepipelines/entrypoint.sh
+++ b/releasepipelines/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-if [ -z "$AZURE_DEVOPS_ORGANIZATION" ]; then
-    echo "AZURE_DEVOPS_ORGANIZATION is not set."
+if [ -z "$AZURE_DEVOPS_URL" -a -z "$AZURE_DEVOPS_ORGANIZATION" ]; then
+    echo "AZURE_DEVOPS_URL and AZURE_DEVOPS_ORGANIZATION are not set." >&2
     exit 1
 fi
 
@@ -21,10 +21,12 @@ if [ -z "$AZURE_PIPELINE_NAME" ]; then
     exit 1
 fi
 
-    
-AZDEVOPS_URL="https://dev.azure.com/${AZURE_DEVOPS_ORGANIZATION}/"
-vsts configure --defaults instance="${AZDEVOPS_URL}" project="${AZURE_DEVOPS_PROJECT}"
-    
+if [ -z "$AZURE_DEVOPS_URL" ]; then
+    AZURE_DEVOPS_URL="https://dev.azure.com/${AZURE_DEVOPS_ORGANIZATION}/"
+fi
+
+vsts configure --defaults instance="${AZURE_DEVOPS_URL}" project="${AZURE_DEVOPS_PROJECT}"
+
 vsts login --token "${AZURE_DEVOPS_TOKEN}"
 
 # List RDs with given pipeline name

--- a/releasepipelines/entrypoint.sh
+++ b/releasepipelines/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-if [ -z "$AZURE_DEVOPS_URL" -a -z "$AZURE_DEVOPS_ORGANIZATION" ]; then
-    echo "AZURE_DEVOPS_URL and AZURE_DEVOPS_ORGANIZATION are not set." >&2
+if [ -z "$AZURE_DEVOPS_URL" ]; then
+    echo "AZURE_DEVOPS_URL is not set." >&2
     exit 1
 fi
 
@@ -19,10 +19,6 @@ fi
 if [ -z "$AZURE_PIPELINE_NAME" ]; then
     echo "AZURE_PIPELINE_NAME is not set."
     exit 1
-fi
-
-if [ -z "$AZURE_DEVOPS_URL" ]; then
-    AZURE_DEVOPS_URL="https://dev.azure.com/${AZURE_DEVOPS_ORGANIZATION}/"
 fi
 
 vsts configure --defaults instance="${AZURE_DEVOPS_URL}" project="${AZURE_DEVOPS_PROJECT}"

--- a/releasepipelines/entrypoint.sh
+++ b/releasepipelines/entrypoint.sh
@@ -7,17 +7,17 @@ if [ -z "$AZURE_DEVOPS_URL" ]; then
 fi
 
 if [ -z "$AZURE_DEVOPS_PROJECT" ]; then
-    echo "AZURE_DEVOPS_PROJECT is not set."
+    echo "AZURE_DEVOPS_PROJECT is not set." >&2
     exit 1
 fi
 
 if [ -z "$AZURE_DEVOPS_TOKEN" ]; then
-    echo "AZURE_DEVOPS_TOKEN is not set."
+    echo "AZURE_DEVOPS_TOKEN is not set." >&2
     exit 1
 fi
 
 if [ -z "$AZURE_PIPELINE_NAME" ]; then
-    echo "AZURE_PIPELINE_NAME is not set."
+    echo "AZURE_PIPELINE_NAME is not set." >&2
     exit 1
 fi
 

--- a/releasepipelines/entrypoint.sh
+++ b/releasepipelines/entrypoint.sh
@@ -1,27 +1,23 @@
 #!/bin/bash
 set -e
 
-if [ -z "$AZURE_PIPELINE_ORGANIZATION" ]; 
-then
-    echo "\$AZURE_PIPELINE_ORGANIZATION is not set."
+if [ -z "$AZURE_PIPELINE_ORGANIZATION" ]; then
+    echo "AZURE_PIPELINE_ORGANIZATION is not set."
     exit 1
 fi
 
-if [ -z "$AZURE_PIPELINE_PROJECT" ];
-then
-    echo "\$AZURE_PIPELINE_PROJECT is not set."
+if [ -z "$AZURE_PIPELINE_PROJECT" ]; then
+    echo "AZURE_PIPELINE_PROJECT is not set."
     exit 1
 fi
 
-if [ -z "$AZURE_PIPELINE_TOKEN" ]; 
-then
-    echo "\$AZURE_PIPELINE_TOKEN is not set."
+if [ -z "$AZURE_PIPELINE_TOKEN" ]; then
+    echo "AZURE_PIPELINE_TOKEN is not set."
     exit 1
 fi
 
-if [ -z "$AZURE_PIPELINE_NAME" ]; 
-then
-    echo "\$AZURE_PIPELINE_NAME is not set."
+if [ -z "$AZURE_PIPELINE_NAME" ]; then
+    echo "AZURE_PIPELINE_NAME is not set."
     exit 1
 fi
 


### PR DESCRIPTION
Changes to the Azure DevOps boards and pipelines actions to allow simplified configuration and wider support.

1. Rename the token, organization and project variables to `AZURE_DEVOPS_*` so that they can be shared between different actions.  This is useful for people who are creating multiple Azure DevOps based actions in a single repository, but it's *particularly* useful for `AZURE_DEVOPS_TOKEN` variables, which are secret variables.  GitHub shares secret variables between all actions, so they'll immediately be inherited.  Users will not have to create a new PAT just to create a new action.

2. Allow `AZURE_DEVOPS_URL` to be specified.  This allows users to target an on-premises Team Foundation Server or Azure DevOps Server instance by specifying the URL to their instance.  For backcompat and simplified configuration, `AZURE_DEVOPS_ORGANIZATION` can still be specified.  If `AZURE_DEVOPS_URL` is not specified, then `AZURE_DEVOPS_ORGANIZATION` will be used to create a URL to Azure DevOps.