### PR TITLE
vsts-cli replaced with azure-devops extension 

### DIFF
--- a/boards/Dockerfile
+++ b/boards/Dockerfile
@@ -1,5 +1,7 @@
 FROM microsoft/azure-cli
 
+RUN az extension add -n azure-devops
+
 RUN apk update \
   && apk add --no-cache jq
 
@@ -16,8 +18,6 @@ LABEL maintainer="Microsoft Corporation"
 LABEL com.github.actions.name="Trigger Azure Boards" 
 LABEL com.github.actions.description="GitHub Action to trigger Azure Boards" 
 LABEL com.github.actions.color="blue"  
-
-RUN az extension add -n azure-devops
 
 COPY entrypoint.sh /entrypoint.sh  
 RUN chmod +x /entrypoint.sh 

--- a/boards/Dockerfile
+++ b/boards/Dockerfile
@@ -1,7 +1,5 @@
 FROM microsoft/azure-cli
 
-RUN az extension add -n azure-devops
-
 RUN apk update \
   && apk add --no-cache jq
 

--- a/boards/Dockerfile
+++ b/boards/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/vsts-cli
+FROM microsoft/azure-cli
 
 RUN apk update \
   && apk add --no-cache jq
@@ -16,6 +16,8 @@ LABEL maintainer="Microsoft Corporation"
 LABEL com.github.actions.name="Trigger Azure Boards" 
 LABEL com.github.actions.description="GitHub Action to trigger Azure Boards" 
 LABEL com.github.actions.color="blue"  
+
+RUN az extension add -n azure-devops
 
 COPY entrypoint.sh /entrypoint.sh  
 RUN chmod +x /entrypoint.sh 

--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -51,7 +51,7 @@ AZURE_DEVOPS_URL="https://dev.azure.com/${AZURE_BOARDS_ORGANIZATION}/"
 
 az devops configure --defaults organization="${AZURE_DEVOPS_URL}" project="${AZURE_BOARDS_PROJECT}"
 
-echo ${AZURE_BOARDS_TOKEN} | az devops login --organization "${AZURE_DEVOPS_URL}"
+echo "${AZURE_BOARDS_TOKEN}" | az devops login --organization "${AZURE_DEVOPS_URL}"
 
 GITHUB_EVENT=$(jq --raw-output 'if .comment != null then "comment" else empty end' "$GITHUB_EVENT_PATH")
 GITHUB_EVENT=${GITHUB_EVENT:-$(jq --raw-output 'if .issue != null then "issue" else empty end' "$GITHUB_EVENT_PATH")}

--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e 
 
+az extension add -n azure-devops
+
 if [ -z "$AZURE_BOARDS_ORGANIZATION" ]; then
     echo "AZURE_BOARDS_ORGANIZATION is not set." >&2
     exit 1

--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -29,7 +29,7 @@ function parse_markdown {
 function create_work_item {
     echo "Creating work item..."
     HYPERLINK="Created from <a href='${GITHUB_ISSUE_HTML_URL}'>Issue #${GITHUB_ISSUE_NUMBER}</a>"
-    RESULTS=$(vsts work item create --type "${AZURE_BOARDS_TYPE}" \
+    RESULTS=$(az boards work-item create --type "${AZURE_BOARDS_TYPE}" \
         --title "${AZURE_BOARDS_TITLE}" \
         --description "${AZURE_BOARDS_DESCRIPTION}" \
         -f System.Tags="GitHub; Issue ${GITHUB_ISSUE_NUMBER}; ${GITHUB_REPO_FULL_NAME}" \
@@ -41,7 +41,7 @@ function create_work_item {
 }
 
 function work_items_for_issue {
-    vsts work item query --wiql "SELECT ID FROM workitems WHERE [System.Tags] CONTAINS 'GitHub' AND [System.Tags] CONTAINS 'Issue ${GITHUB_ISSUE_NUMBER}' AND [System.Tags] CONTAINS '${GITHUB_REPO_FULL_NAME}'" | jq '.[].id' | xargs
+    az boards work-item query --wiql "SELECT ID FROM workitems WHERE [System.Tags] CONTAINS 'GitHub' AND [System.Tags] CONTAINS 'Issue ${GITHUB_ISSUE_NUMBER}' AND [System.Tags] CONTAINS '${GITHUB_REPO_FULL_NAME}'" | jq '.[].id' | xargs
 }
 
 AZURE_BOARDS_TYPE="${AZURE_BOARDS_TYPE:-Feature}"
@@ -49,9 +49,9 @@ AZURE_BOARDS_CLOSED_STATE="${AZURE_BOARDS_CLOSED_STATE:-Closed}"
 AZURE_BOARDS_REOPENED_STATE="${AZURE_BOARDS_REOPENED_STATE:-Active}"
 AZURE_DEVOPS_URL="https://dev.azure.com/${AZURE_BOARDS_ORGANIZATION}/"
 
-vsts configure --defaults instance="${AZURE_DEVOPS_URL}" project="${AZURE_BOARDS_PROJECT}"
+az devops configure --defaults instance="${AZURE_DEVOPS_URL}" project="${AZURE_BOARDS_PROJECT}"
 
-vsts login --token "${AZURE_BOARDS_TOKEN}"
+az devops login --token "${AZURE_BOARDS_TOKEN}"
 
 GITHUB_EVENT=$(jq --raw-output 'if .comment != null then "comment" else empty end' "$GITHUB_EVENT_PATH")
 GITHUB_EVENT=${GITHUB_EVENT:-$(jq --raw-output 'if .issue != null then "issue" else empty end' "$GITHUB_EVENT_PATH")}
@@ -94,7 +94,7 @@ case "$TRIGGER" in
 
     for ID in $(work_items_for_issue); do
         echo "Setting work item ${ID} to state ${NEW_STATE}..."
-        RESULTS=$(vsts work item update --id "$ID" --state "$NEW_STATE")
+        RESULTS=$(az boards work-item update --id "$ID" --state "$NEW_STATE")
 
         RESULT_STATE=$(echo "${RESULTS}" | jq --raw-output '.fields["System.State"]')
         echo "Work item ${ID} is now ${RESULT_STATE}"
@@ -109,7 +109,7 @@ case "$TRIGGER" in
         BODY=$(jq --raw-output .comment.body "$GITHUB_EVENT_PATH" | parse_markdown)
 
         echo "Adding comment to work item ${ID}..."
-        RESULTS=$(vsts work item update --id "$ID" --discussion "<p>${HEADER}</p>${BODY}")
+        RESULTS=$(az boards work-item work item update --id "$ID" --discussion "<p>${HEADER}</p>${BODY}")
     done
     ;;
 esac

--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -49,7 +49,7 @@ AZURE_BOARDS_CLOSED_STATE="${AZURE_BOARDS_CLOSED_STATE:-Closed}"
 AZURE_BOARDS_REOPENED_STATE="${AZURE_BOARDS_REOPENED_STATE:-Active}"
 AZURE_DEVOPS_URL="https://dev.azure.com/${AZURE_BOARDS_ORGANIZATION}/"
 
-az devops configure --defaults instance="${AZURE_DEVOPS_URL}" project="${AZURE_BOARDS_PROJECT}"
+az devops configure --defaults organization="${AZURE_DEVOPS_URL}" project="${AZURE_BOARDS_PROJECT}"
 
 az devops login --token "${AZURE_BOARDS_TOKEN}"
 

--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -53,7 +53,7 @@ AZURE_BOARDS_REOPENED_STATE="${AZURE_BOARDS_REOPENED_STATE:-Active}"
 
 az devops configure --defaults organization="${AZURE_DEVOPS_URL}" project="${AZURE_DEVOPS_PROJECT}"
 
-echo "${AZURE_BOARDS_TOKEN}" | az devops login --organization "${AZURE_DEVOPS_URL}"
+echo "${AZURE_DEVOPS_TOKEN}" | az devops login --organization "${AZURE_DEVOPS_URL}"
 
 GITHUB_EVENT=$(jq --raw-output 'if .comment != null then "comment" else empty end' "$GITHUB_EVENT_PATH")
 GITHUB_EVENT=${GITHUB_EVENT:-$(jq --raw-output 'if .issue != null then "issue" else empty end' "$GITHUB_EVENT_PATH")}

--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -51,7 +51,7 @@ AZURE_DEVOPS_URL="https://dev.azure.com/${AZURE_BOARDS_ORGANIZATION}/"
 
 az devops configure --defaults organization="${AZURE_DEVOPS_URL}" project="${AZURE_BOARDS_PROJECT}"
 
-az devops login --token "${AZURE_BOARDS_TOKEN}"
+echo ${AZURE_BOARDS_TOKEN} | az devops login --organization "${AZURE_DEVOPS_URL}"
 
 GITHUB_EVENT=$(jq --raw-output 'if .comment != null then "comment" else empty end' "$GITHUB_EVENT_PATH")
 GITHUB_EVENT=${GITHUB_EVENT:-$(jq --raw-output 'if .issue != null then "issue" else empty end' "$GITHUB_EVENT_PATH")}
@@ -109,7 +109,7 @@ case "$TRIGGER" in
         BODY=$(jq --raw-output .comment.body "$GITHUB_EVENT_PATH" | parse_markdown)
 
         echo "Adding comment to work item ${ID}..."
-        RESULTS=$(az boards work-item work item update --id "$ID" --discussion "<p>${HEADER}</p>${BODY}")
+        RESULTS=$(az boards work-item update --id "$ID" --discussion "<p>${HEADER}</p>${BODY}")
     done
     ;;
 esac

--- a/pipelines/Dockerfile
+++ b/pipelines/Dockerfile
@@ -1,14 +1,16 @@
-FROM microsoft/vsts-cli
+FROM microsoft/azure-cli
 
 RUN apk update \
   && apk add --no-cache jq
 
 LABEL version="1.0.0"
 
-LABEL maintainer="Microsoft Corporation" 
-LABEL com.github.actions.name="Trigger Azure Pipelines" 
-LABEL com.github.actions.description="GitHub Action to trigger Azure pipeline" 
-LABEL com.github.actions.color="blue"  
+LABEL maintainer="Microsoft Corporation"
+LABEL com.github.actions.name="Trigger Azure Pipelines"
+LABEL com.github.actions.description="GitHub Action to trigger Azure pipeline"
+LABEL com.github.actions.color="blue"
+
+RUN az extension add -n azure-devops  
 
 COPY entrypoint.sh /entrypoint.sh  
 RUN chmod +x /entrypoint.sh 

--- a/pipelines/Dockerfile
+++ b/pipelines/Dockerfile
@@ -1,4 +1,5 @@
 FROM microsoft/azure-cli
+RUN az extension add -n azure-devops  
 
 RUN apk update \
   && apk add --no-cache jq
@@ -9,8 +10,6 @@ LABEL maintainer="Microsoft Corporation"
 LABEL com.github.actions.name="Trigger Azure Pipelines"
 LABEL com.github.actions.description="GitHub Action to trigger Azure pipeline"
 LABEL com.github.actions.color="blue"
-
-RUN az extension add -n azure-devops  
 
 COPY entrypoint.sh /entrypoint.sh  
 RUN chmod +x /entrypoint.sh 

--- a/pipelines/Dockerfile
+++ b/pipelines/Dockerfile
@@ -1,5 +1,4 @@
 FROM microsoft/azure-cli
-RUN az extension add -n azure-devops  
 
 RUN apk update \
   && apk add --no-cache jq

--- a/pipelines/Dockerfile
+++ b/pipelines/Dockerfile
@@ -5,10 +5,10 @@ RUN apk update \
 
 LABEL version="1.0.0"
 
-LABEL maintainer="Microsoft Corporation"
-LABEL com.github.actions.name="Trigger Azure Pipelines"
-LABEL com.github.actions.description="GitHub Action to trigger Azure pipeline"
-LABEL com.github.actions.color="blue"
+LABEL maintainer="Microsoft Corporation" 
+LABEL com.github.actions.name="Trigger Azure Pipelines" 
+LABEL com.github.actions.description="GitHub Action to trigger Azure pipeline" 
+LABEL com.github.actions.color="blue"  
 
 COPY entrypoint.sh /entrypoint.sh  
 RUN chmod +x /entrypoint.sh 

--- a/pipelines/entrypoint.sh
+++ b/pipelines/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e 
 
+az extension add -n azure-devops
+
 if [ -z "$AZURE_PIPELINE_ORGANIZATION" ]; 
 then
     echo "\$AZURE_PIPELINE_ORGANIZATION is not set." >&2

--- a/pipelines/entrypoint.sh
+++ b/pipelines/entrypoint.sh
@@ -30,7 +30,7 @@ fi
 AZDEVOPS_URL="https://dev.azure.com/${AZURE_PIPELINE_ORGANIZATION}/"
 az devops configure --defaults organization="${AZDEVOPS_URL}" project="${AZURE_PIPELINE_PROJECT}"
     
-echo ${AZURE_PIPELINE_TOKEN} | az devops login --organization "${AZDEVOPS_URL}"
+echo "${AZURE_PIPELINE_TOKEN}" | az devops login --organization "${AZDEVOPS_URL}"
     
 PIPELINES=$(az pipelines build definition list --name "${AZURE_PIPELINE_NAME}" --output json)
 

--- a/pipelines/entrypoint.sh
+++ b/pipelines/entrypoint.sh
@@ -30,7 +30,7 @@ fi
 AZDEVOPS_URL="https://dev.azure.com/${AZURE_PIPELINE_ORGANIZATION}/"
 az devops configure --defaults organization="${AZDEVOPS_URL}" project="${AZURE_PIPELINE_PROJECT}"
     
-az devops login --token "${AZURE_PIPELINE_TOKEN}"
+echo ${AZURE_PIPELINE_TOKEN} | az devops login --organization "${AZDEVOPS_URL}"
     
 PIPELINES=$(az pipelines build definition list --name "${AZURE_PIPELINE_NAME}" --output json)
 

--- a/pipelines/entrypoint.sh
+++ b/pipelines/entrypoint.sh
@@ -28,11 +28,11 @@ fi
 
     
 AZDEVOPS_URL="https://dev.azure.com/${AZURE_PIPELINE_ORGANIZATION}/"
-vsts configure --defaults instance="${AZDEVOPS_URL}" project="${AZURE_PIPELINE_PROJECT}"
+az devops configure --defaults organization="${AZDEVOPS_URL}" project="${AZURE_PIPELINE_PROJECT}"
     
-vsts login --token "${AZURE_PIPELINE_TOKEN}"
+az devops login --token "${AZURE_PIPELINE_TOKEN}"
     
-PIPELINES=$(vsts build definition list --name "${AZURE_PIPELINE_NAME}" --output json)
+PIPELINES=$(az pipelines build definition list --name "${AZURE_PIPELINE_NAME}" --output json)
 
 if ! (echo "${PIPELINES}" | jq -e .); then
     echo "Failed to fetch pipelines. Error: ${PIPELINES}"
@@ -54,7 +54,7 @@ then
 fi
 
 BUILD_DEFINITION_ID=$(echo "${PIPELINES}" | jq -r ".[0]?.id //empty")
-BUILD_DEFINITION=$(vsts build definition show --id "${BUILD_DEFINITION_ID}" --output json)
+BUILD_DEFINITION=$(az pipelines build definition show --id "${BUILD_DEFINITION_ID}" --output json)
 
 if ! (echo "${BUILD_DEFINITION}" | jq -e .); then
     echo "Failed to  get pipeline using Id: ${BUILD_DEFINITION_ID}. Error: ${BUILD_DEFINITION}"
@@ -66,9 +66,9 @@ REPOSITORY_TYPE=$(echo "${BUILD_DEFINITION}" | jq  -r ".repository?.type?  //emp
 
 if [ -n "$REPOSITORY_NAME" ] && [ -n "$REPOSITORY_TYPE" ] && [ "$REPOSITORY_NAME" = "$GITHUB_REPOSITORY" ] && [ "$REPOSITORY_TYPE" = "GitHub" ]; 
 then
-    BUILD_OUTPUT=$(vsts build queue --definition-name "${AZURE_PIPELINE_NAME}" --branch "${GITHUB_REF}" --commit-id "${GITHUB_SHA}" --output json)
+    BUILD_OUTPUT=$(az pipelines build queue --definition-name "${AZURE_PIPELINE_NAME}" --branch "${GITHUB_REF}" --commit-id "${GITHUB_SHA}" --output json)
 else
-    BUILD_OUTPUT=$(vsts build queue --definition-name "${AZURE_PIPELINE_NAME}" --output json)
+    BUILD_OUTPUT=$(az pipelines build queue --definition-name "${AZURE_PIPELINE_NAME}" --output json)
 fi
 
 if [ -z "$BUILD_OUTPUT" ];

--- a/releasepipelines/Dockerfile
+++ b/releasepipelines/Dockerfile
@@ -1,7 +1,5 @@
 FROM microsoft/azure-cli
 
-RUN az extension add -n azure-devops
-
 RUN apk update \
   && apk add --no-cache jq
 

--- a/releasepipelines/Dockerfile
+++ b/releasepipelines/Dockerfile
@@ -1,5 +1,7 @@
 FROM microsoft/azure-cli
 
+RUN az extension add -n azure-devops
+
 RUN apk update \
   && apk add --no-cache jq
 
@@ -9,8 +11,6 @@ LABEL maintainer="Microsoft Corporation"
 LABEL com.github.actions.name="Trigger Azure Release Pipelines" 
 LABEL com.github.actions.description="GitHub Action to trigger Azure release pipeline" 
 LABEL com.github.actions.color="blue"  
-
-RUN az extension add -n azure-devops
 
 COPY entrypoint.sh /entrypoint.sh  
 RUN chmod +x /entrypoint.sh 

--- a/releasepipelines/Dockerfile
+++ b/releasepipelines/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/vsts-cli
+FROM microsoft/azure-cli
 
 RUN apk update \
   && apk add --no-cache jq
@@ -9,6 +9,8 @@ LABEL maintainer="Microsoft Corporation"
 LABEL com.github.actions.name="Trigger Azure Release Pipelines" 
 LABEL com.github.actions.description="GitHub Action to trigger Azure release pipeline" 
 LABEL com.github.actions.color="blue"  
+
+RUN az extension add -n azure-devops
 
 COPY entrypoint.sh /entrypoint.sh  
 RUN chmod +x /entrypoint.sh 

--- a/releasepipelines/entrypoint.sh
+++ b/releasepipelines/entrypoint.sh
@@ -29,7 +29,7 @@ fi
 AZDEVOPS_URL="https://dev.azure.com/${AZURE_PIPELINE_ORGANIZATION}/"
 az devops configure --defaults organization="${AZDEVOPS_URL}" project="${AZURE_PIPELINE_PROJECT}"
     
-az devops login --token "${AZURE_PIPELINE_TOKEN}"
+echo ${AZURE_PIPELINE_TOKEN} | az devops login --organization "${AZDEVOPS_URL}"
 
 # List RDs with given pipeline name
 PIPELINES=$(az pipelines release definition list --name "${AZURE_PIPELINE_NAME}")

--- a/releasepipelines/entrypoint.sh
+++ b/releasepipelines/entrypoint.sh
@@ -29,7 +29,7 @@ fi
 AZDEVOPS_URL="https://dev.azure.com/${AZURE_PIPELINE_ORGANIZATION}/"
 az devops configure --defaults organization="${AZDEVOPS_URL}" project="${AZURE_PIPELINE_PROJECT}"
     
-echo ${AZURE_PIPELINE_TOKEN} | az devops login --organization "${AZDEVOPS_URL}"
+echo "${AZURE_PIPELINE_TOKEN}" | az devops login --organization "${AZDEVOPS_URL}"
 
 # List RDs with given pipeline name
 PIPELINES=$(az pipelines release definition list --name "${AZURE_PIPELINE_NAME}")

--- a/releasepipelines/entrypoint.sh
+++ b/releasepipelines/entrypoint.sh
@@ -27,12 +27,12 @@ fi
 
     
 AZDEVOPS_URL="https://dev.azure.com/${AZURE_PIPELINE_ORGANIZATION}/"
-vsts configure --defaults instance="${AZDEVOPS_URL}" project="${AZURE_PIPELINE_PROJECT}"
+az devops configure --defaults instance="${AZDEVOPS_URL}" project="${AZURE_PIPELINE_PROJECT}"
     
-vsts login --token "${AZURE_PIPELINE_TOKEN}"
+az devops login --token "${AZURE_PIPELINE_TOKEN}"
 
 # List RDs with given pipeline name
-PIPELINES=$(vsts release definition list --name "${AZURE_PIPELINE_NAME}")
+PIPELINES=$(az pipelines release definition list --name "${AZURE_PIPELINE_NAME}")
 
 if ! (echo "${PIPELINES}" | jq -e .); then
     echo "Failed to fetch release definitions. Error: ${PIPELINES}"
@@ -64,7 +64,7 @@ then
 fi
 
 
-RELEASE_DEFINITION=$(vsts release definition show --name "${AZURE_PIPELINE_NAME}")
+RELEASE_DEFINITION=$(az pipelines release definition show --name "${AZURE_PIPELINE_NAME}")
 
 if ! (echo "${RELEASE_DEFINITION}" | jq -e .); then
     echo "Failed to fetch release pipeline. Error: ${RELEASE_DEFINITION}"
@@ -84,8 +84,8 @@ ALIAS=$(echo "${RELEASE_DEFINITION}" | jq -r ".artifacts[]? | select((.type==\"$
 if [ -n "$ALIAS" ]; 
 then
     echo "Triggering Azure release pipeline for : '${AZURE_PIPELINE_NAME}' for commitId: '${GITHUB_SHA}'."
-    vsts release create --definition-name "${AZURE_PIPELINE_NAME}" --artifact-metadata-list "$ALIAS"="$GITHUB_SHA"
+    az pipelines release create --definition-name "${AZURE_PIPELINE_NAME}" --artifact-metadata-list "$ALIAS"="$GITHUB_SHA"
 else
     echo "Triggering Azure release pipeline: '${AZURE_PIPELINE_NAME}'"
-    vsts release create --definition-name "${AZURE_PIPELINE_NAME}"
+    az pipelines release create --definition-name "${AZURE_PIPELINE_NAME}"
 fi  

--- a/releasepipelines/entrypoint.sh
+++ b/releasepipelines/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+az extension add -n azure-devops
+
 if [ -z "$AZURE_PIPELINE_ORGANIZATION" ]; 
 then
     echo "\$AZURE_PIPELINE_ORGANIZATION is not set."

--- a/releasepipelines/entrypoint.sh
+++ b/releasepipelines/entrypoint.sh
@@ -27,7 +27,7 @@ fi
 
     
 AZDEVOPS_URL="https://dev.azure.com/${AZURE_PIPELINE_ORGANIZATION}/"
-az devops configure --defaults instance="${AZDEVOPS_URL}" project="${AZURE_PIPELINE_PROJECT}"
+az devops configure --defaults organization="${AZDEVOPS_URL}" project="${AZURE_PIPELINE_PROJECT}"
     
 az devops login --token "${AZURE_PIPELINE_TOKEN}"
 


### PR DESCRIPTION
**Changes include-**
1. Using azure-cli docker base image instead of vsts-cli 
2. Install devops extension on azure cli 
3. Change all scripts to consume the az devops extension instead of vsts-cli

**Known Issue:** 
Adding the az extension add -n azure-devops step in the dockerfile did not reflect in the image when running through github actions. That is still the right place for that step. For the moment the step is run in the entrypoint.sh script.  


**Validation Testing done**
1. Created Pipelines and ReleasePipeline Action and verified [here](https://github.com/azooinmyluggage/express-draft/pull/41).
1. Created WIT action and verified end to end copy issues to [azure boards is working](https://github.com/azooinmyluggage/express-draft/actions).
