### PR TITLE
Update version for the Azure CLI Docker Image

### DIFF
--- a/storage-blob-static-website/Dockerfile
+++ b/storage-blob-static-website/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/azure-cli:2.0.64 
+FROM microsoft/azure-cli:2.0.64
 
 LABEL version="1.0.1"
 LABEL maintainer="Microsoft Corporation"

--- a/storage-blob-static-website/Dockerfile
+++ b/storage-blob-static-website/Dockerfile
@@ -1,6 +1,6 @@
-FROM microsoft/azure-cli:2.0.47
+FROM microsoft/azure-cli
 
-LABEL version="1.0.0"
+LABEL version="1.0.1"
 LABEL maintainer="Microsoft Corporation"
 LABEL com.github.actions.name="Deploy to Azure Blob Storage for Static Website Hosting"
 LABEL com.github.actions.description="GitHub Action for deploying a static website in Azure Blob Storage"

--- a/storage-blob-static-website/Dockerfile
+++ b/storage-blob-static-website/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/azure-cli
+FROM microsoft/azure-cli:2.0.64 
 
 LABEL version="1.0.1"
 LABEL maintainer="Microsoft Corporation"

--- a/storage-blob-static-website/README.md
+++ b/storage-blob-static-website/README.md
@@ -32,8 +32,9 @@ action "Upload to Static Website in Azure Blob Storage" {
 - `NOT_FOUND_FILE` - *Optional* (defaults to `404.html`)
   > The file to be used in case of a `404` status code
 
-- `SHOULD_EMPTY` - *Optional* (defaults to false)
+- `SHOULD_EMPTY` - *Optional*
   > Whether the `$web` container should be emptied before uploading new content
+  > Set to `true` if you wish to empty the `$web` container before uploading.
 
 ### Secrets
 


### PR DESCRIPTION
## Changes

This PR removes the Docker Image version from the `microsoft/azure-cli` in the `Dockerfile` for the GH Action to deploy a website to static hosting on Blob Storage.

## Rationale

I based this on another action which used a versioned image, but noticed that an old version may prove problematic when installing extensions (in this case, the `storage-preview` extension. So `az extension add --name storage-preview` may exit with an error code).

The version that was defined for the existing image (`2.0.47`) conflicts with the minimum version required for the CLI (as of the time of this writing, `2.0.52` as can be [seen here](https://github.com/Azure/azure-cli-extensions/blob/master/src/storage-preview/azext_storage_preview/azext_metadata.json#L2)).

---

Also took this opportunity to improve the `README` a bit.

