### PR TITLE
Fix use of boards query

### DIFF
--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -43,7 +43,7 @@ function create_work_item {
 }
 
 function work_items_for_issue {
-    az boards work-item query --wiql "SELECT ID FROM workitems WHERE [System.Tags] CONTAINS 'GitHub' AND [System.Tags] CONTAINS 'Issue ${GITHUB_ISSUE_NUMBER}' AND [System.Tags] CONTAINS '${GITHUB_REPO_FULL_NAME}'" | jq '.[].id' | xargs
+    az boards query --wiql "SELECT ID FROM workitems WHERE [System.Tags] CONTAINS 'GitHub' AND [System.Tags] CONTAINS 'Issue ${GITHUB_ISSUE_NUMBER}' AND [System.Tags] CONTAINS '${GITHUB_REPO_FULL_NAME}'" | jq '.[].id' | xargs
 }
 
 AZURE_BOARDS_TYPE="${AZURE_BOARDS_TYPE:-Feature}"


### PR DESCRIPTION
It seems that command __az boards worki-item__ doesn't contains command __query__. 

In the documentation it is directly on boards command [az-boards-query](https://docs.microsoft.com/en-us/cli/azure/ext/azure-devops/boards?view=azure-cli-latest#ext-azure-devops-az-boards-query)